### PR TITLE
feat: tree shake lodash functions

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -1,7 +1,8 @@
 import { Chart, ChartData, ChartOptions, ChartType, Plugin, ChartDataset } from 'chart.js';
 import { ref, defineComponent, PropType, onMounted, h, onBeforeUnmount, watch } from 'vue-demi';
 import { CSSProperties } from '@vue/runtime-dom';
-import { startCase, camelCase } from 'lodash';
+import startCase from 'lodash/startCase';
+import camelCase from 'lodash/camelCase';
 
 export type StyleValue = string | CSSProperties | Array<StyleValue>;
 


### PR DESCRIPTION
Currently it pulls in the whole library, resulting in a pretty big bundle size:
https://bundlephobia.com/package/vue-chart-3@0.1.6

As you can see 96.4% is because of the Lodash usage.

I couldn't get the project to fully build since it was complaining about TypeErrors, so I am not sure if I need to commit more changes.