### PR TITLE
change hooks.ts Plugin interface class type.

### DIFF
--- a/packages/vue-chart-3/src/hooks.ts
+++ b/packages/vue-chart-3/src/hooks.ts
@@ -1,4 +1,4 @@
-import { Chart, ChartData, ChartOptions, ChartType } from 'chart.js';
+import { Chart, ChartData, ChartOptions, ChartType, Plugin } from 'chart.js';
 import {
   computed,
   onBeforeMount,


### PR DESCRIPTION
Hi pls check it.
I got error using plugins because of type of Plugin in types/hooks.d.ts.

using Plugin in chart.js is correct ?
https://github.com/victorgarciaesgi/vue-chart-3/blob/main/packages/vue-chart-3/types/hooks.d.ts#L1

![Screen Shot 2021-10-15 at 1 05 58](https://user-images.githubusercontent.com/979417/137357968-d216ee2a-ec0d-4f14-a1e5-5a849396df26.png)

![Screen Shot 2021-10-15 at 1 18 49](https://user-images.githubusercontent.com/979417/137358034-aa00c2ee-0f00-41e1-b4a8-474796512e81.png)