### PR TITLE
Update example by including chart registration

### DIFF
--- a/docs/guide/usage/README.md
+++ b/docs/guide/usage/README.md
@@ -12,6 +12,9 @@ Here is an example with static data
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { DoughnutChart } from 'vue-chart-3';
+import { Chart, registerables } from "chart.js";
+
+Chart.register(...registerables);
 
 export default defineComponent({
   name: 'Home',


### PR DESCRIPTION
This small change would complete the example shown in the docs, helping especially new users to render their first chart by simply copy pasting it into their app.

I never worked with Chart.js before and my first thought was that this lib might not work with Vite... turned out I just needed to register the charts and voilá ✨ 

In case you're interested: A minimal Vite, Vue, vue-chart-3 app: https://stackblitz.com/edit/vitejs-vite-1nhzrw?file=src/App.vue (run `vite` in the console to start)
