### PR TITLE
chore(deps): fix installation warning for vue composition api

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "type": "commonjs",
   "license": "MIT",
   "peerDependencies": {
-    "@vue/composition-api": "^1.0.4",
+    "@vue/composition-api": "^1.4.1",
     "chart.js": "^3.1.0",
     "vue": "^2.0.0"
   },
@@ -56,7 +56,7 @@
     "@types/lodash": "^4.14.178",
     "@types/node": "^16.11.12",
     "@vue/cli": "^4.5.15",
-    "@vue/composition-api": "^1.4.0",
+    "@vue/composition-api": "^1.4.1",
     "@vue/test-utils": "^1.3.0",
     "canvas": "^2.8.0",
     "chart.js": "^3.6.2",


### PR DESCRIPTION
The same version number should be used in all places.