### PR TITLE
Use lodash es

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry="https://registry.yarnpkg.com"

--- a/debug/vue3/src/App.vue
+++ b/debug/vue3/src/App.vue
@@ -4,7 +4,7 @@ import { BarChart, useBarChart } from 'vue-chart-3';
 // import { BarChart, defineChartComponent, useBarChart } from '../../../dist';
 
 import { ref, computed, defineComponent } from 'vue';
-import { shuffle } from 'lodash';
+import { shuffle } from 'lodash-es';
 
 Chart.register(...registerables);
 

--- a/docs/components/hooks/example.md
+++ b/docs/components/hooks/example.md
@@ -12,7 +12,7 @@
 import { Chart, registerables } from 'chart.js';
 import { BarChart, useBarChart } from 'vue-chart-3';
 import { ref, computed, defineComponent } from '@vue/composition-api';
-import { shuffle } from 'lodash';
+import { shuffle } from 'lodash-es';
 
 Chart.register(...registerables);
 

--- a/docs/guide/usage/chart-instance.md
+++ b/docs/guide/usage/chart-instance.md
@@ -9,7 +9,7 @@ It is also passed in events (`chart-render` and `chart-update`)
 </template>
 
 <script>
-import { shuffle } from 'lodash';
+import { shuffle } from 'lodash-es';
 import { computed, defineComponent, ref, onMounted } from 'vue';
 import { DoughnutChart } from 'vue-chart-3';
 

--- a/docs/guide/usage/dynamic-data.md
+++ b/docs/guide/usage/dynamic-data.md
@@ -11,7 +11,7 @@ Each component will trigger an update on the chart when the data passed thought 
 </template>
 
 <script>
-import { shuffle } from 'lodash';
+import { shuffle } from 'lodash-es';
 import { computed, defineComponent, ref } from 'vue';
 import { DoughnutChart } from 'vue-chart-3';
 

--- a/docs/guide/usage/typescript.md
+++ b/docs/guide/usage/typescript.md
@@ -13,7 +13,7 @@ Each component props is properly typed and should be throwing errors if you are 
 </template>
 
 <script lang="ts">
-import { shuffle } from 'lodash';
+import { shuffle } from 'lodash-es';
 import { computed, defineComponent, ref } from 'vue';
 import { DoughnutChart, ExtractComponentData } from 'vue-chart-3';
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    "^lodash-es$": "lodash"
+  }
 };

--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
     "@vue/runtime-core": "3.2.29",
     "@vue/runtime-dom": "3.2.29",
     "csstype": "3.0.10",
-    "lodash": "latest",
+    "lodash-es": "^4.17.21",
     "nanoid": "3.2.0"
   },
   "devDependencies": {
     "@types/chart.js": "^2.9.35",
     "@types/jest": "^27.4.0",
-    "@types/lodash": "^4.14.178",
+    "@types/lodash-es": "^4.17.6",
     "@types/node": "^14.0.27",
     "@vue/cli": "^4.5.15",
     "@vue/test-utils": "^2.0.0-rc.16",

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,6 +1,6 @@
 import { Chart, ChartData, ChartDataset, ChartOptions, ChartType, Plugin } from 'chart.js';
-import cloneDeep from 'lodash/cloneDeep';
-import isEqual from 'lodash/isEqual';
+import { cloneDeep } from 'lodash-es';
+import { isEqual } from 'lodash-es';
 import { nanoid } from 'nanoid';
 import {
   defineComponent,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { ComponentPropsOptions } from '@vue/runtime-core';
 import * as CSS from 'csstype';
-import camelCase from 'lodash/camelCase';
-import startCase from 'lodash/startCase';
+import { camelCase } from 'lodash-es';
+import { startCase } from 'lodash-es';
 
 import { ComputedRef, DefineComponent, Prop, Ref } from 'vue';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,7 +1986,14 @@
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
-"@types/lodash@^4.14.178":
+"@types/lodash-es@^4.17.6":
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.6.tgz#c2ed4c8320ffa6f11b43eb89e9eaeec65966a0a0"
+  integrity sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
   version "4.14.178"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
   integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
@@ -7754,6 +7761,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
Removing lodash in favor of lodash-es. Vite / rollup in production can shake out the unused lodash functions allowing for a smaller build. I also set the registry so that npm registry users wouldn't overwrite by acccident