### PR TITLE
Make package compatible with charts.js 4.X

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "chart.js": "=> ^3.1.0",
+    "chart.js": "^3.0.0 || ^4.0.0",
     "vue": ">= 3"
   },
   "dependencies": {


### PR DESCRIPTION
the library is compatible with charts.js 4.X but will failed on npm install with node 18: 
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: vue-chart-3@3.1.8
npm ERR! Found: chart.js@4.1.1
npm ERR! node_modules/chart.js
npm ERR!   chart.js@"^4.1.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer chart.js@"=> ^3.1.0" from vue-chart-3@3.1.8
npm ERR! node_modules/vue-chart-3
npm ERR!   vue-chart-3@"^3.1.8" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: chart.js@3.9.1
npm ERR! node_modules/chart.js
npm ERR!   peer chart.js@"=> ^3.1.0" from vue-chart-3@3.1.8
npm ERR!   node_modules/vue-chart-3
npm ERR!     vue-chart-3@"^3.1.8" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```